### PR TITLE
Add USI Life Support habitat values

### DIFF
--- a/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport
+++ b/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport
@@ -1,7 +1,7 @@
 // USI Life Support habitat functions
 
 //PXL-9 Extra-Planetary Octo-Aperture Module
-@PART[crewpod-cupola-375]
+@PART[crewpod-cupola-375]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -24,7 +24,7 @@
 }
 
 //PPD-20 Shanty Habitation Module
-@PART[crewpod-habitation-25]
+@PART[crewpod-habitation-25]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -46,7 +46,7 @@
 }
 
 //PXL-1 'Hostel' Deep-Space Habitation Module
-@PART[crewpod-habitation-375]
+@PART[crewpod-habitation-375]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -68,7 +68,7 @@
 }
 
 //PPD-24 Observation Module
-@PART[crewpod-observation-25]
+@PART[crewpod-observation-25]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -90,7 +90,7 @@
 }
 
 //PXL-2 Pressurized Conical Storage Container
-@PART[crewtube-25-375-1]
+@PART[crewtube-25-375-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{

--- a/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport
+++ b/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport
@@ -1,0 +1,113 @@
+// USI Life Support habitat functions
+
+//PXL-9 Extra-Planetary Octo-Aperture Module
+@PART[crewpod-cupola-375]
+{
+	MODULE
+	{
+		name = ModuleLifeSupport
+	}
+	
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 400 //100 * crew capacity + 100 * Kerbal-Months
+		maxAmount = 400
+	}
+	
+	MODULE
+	{
+		name = ModuleHabitation
+		KerbalMonths = 0
+		HabMultiplier = 3.75 //equal to mass
+	}
+}
+
+//PPD-20 Shanty Habitation Module
+@PART[crewpod-habitation-25]
+{
+	MODULE
+	{
+		name = ModuleLifeSupport
+	}
+	
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 2475 //100 * crew capacity + 100 * Kerbal-Months
+		maxAmount = 2475
+	}
+	
+	MODULE
+	{
+		name = ModuleHabitation
+		KerbalMonths = 18.75 //mass * 5
+	}
+}
+
+//PXL-1 'Hostel' Deep-Space Habitation Module
+@PART[crewpod-habitation-375]
+{
+	MODULE
+	{
+		name = ModuleLifeSupport
+	}
+	
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 3300 //100 * crew capacity + 100 * Kerbal-Months
+		maxAmount = 3300
+	}
+	
+	MODULE
+	{
+		name = ModuleHabitation
+		KerbalMonths = 25 //mass * 5
+	}
+}
+
+//PPD-24 Observation Module
+@PART[crewpod-observation-25]
+{
+	MODULE
+	{
+		name = ModuleLifeSupport
+	}
+	
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 400 //100 * crew capacity + 100 * Kerbal-Months
+		maxAmount = 400
+	}
+	
+	MODULE
+	{
+		name = ModuleHabitation
+		HabMultiplier = 3.5 //equal to mass
+	}
+}
+
+//PXL-2 Pressurized Conical Storage Container
+@PART[crewtube-25-375-1]
+{
+	MODULE
+	{
+		name = ModuleLifeSupport
+	}
+	
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 1800 //100 * crew capacity + 100 * Kerbal-Months
+		maxAmount = 1800
+	}
+	
+	MODULE
+	{
+		name = ModuleHabitation
+		KerbalMonths = 14 //mass * 5
+	}
+}
+


### PR DESCRIPTION
Adds support for USI Life Support habitation functions. Cupolae act as hab multipliers; hab modules add to living space.
