### PR TITLE
Update patch for USI-LS

### DIFF
--- a/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport.cfg
+++ b/GameData/StationPartsExpansion/Patches/SSPXUSILifeSupport.cfg
@@ -1,280 +1,147 @@
 // USI Life Support habitat functions
 
-//PXL-9 Extra-Planetary Octo-Aperture Module
-@PART[crewpod-cupola-375]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 400 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 400
-	}
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 0
-		BaseHabMultiplier = 3.75 //equal to mass
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
 //PPD-20 Shanty Habitation Module
-@PART[crewpod-habitation-25]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 2475 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 2475
-	}
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 18.75 //mass * 5
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
 //PXL-1 'Hostel' Deep-Space Habitation Module
-@PART[crewpod-habitation-375]:NEEDS[USILifeSupport]
+//PXL-2 Pressurized Conical Storage Container
+@PART[crewpod-habitation-25|crewpod-habitation-375|crewtube-25-375-1]:NEEDS[USILifeSupport]
 {
-	%MODULE[ModuleLifeSupport] { }
+	%MODULE[ModuleLifeSupport]{}
+	%MODULE[USI_ModuleFieldRepair]{}
 
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 3300 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 3300
-	}
-
+	!MODULE[ModuleHabitation]{}
 	MODULE
 	{
 		name = ModuleHabitation
-		KerbalMonths = 25 //mass * 5
+		BaseKerbalMonths = #$/mass$ 
+		@BaseKerbalMonths *= 10
+		@BaseKerbalMonths -= #$/CrewCapacity$
+		CrewCapacity = #$/CrewCapacity$
+		BaseHabMultiplier = 0
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = #$../BaseKerbalMonths$ 
+			@Ratio *= .25
+		}
 	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
+	
+	!RESOURCE[ReplacementParts]{}
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = #$/mass$ 
+		@amount *= 1000
+		maxAmount = #$amount$
+	}
 }
 
 //PPD-24 Observation Module
-@PART[crewpod-observation-25]:NEEDS[USILifeSupport]
+//PXL-9 Extra-Planetary Octo-Aperture Module
+@PART[crewpod-observation-25|crewpod-cupola-375]:NEEDS[USILifeSupport]
 {
-	%MODULE[ModuleLifeSupport] { }
+	%MODULE[ModuleLifeSupport]{}
+	%MODULE[USI_ModuleFieldRepair]{}
 
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 400 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 400
-	}
-
+	!MODULE[ModuleHabitation]{}
 	MODULE
 	{
 		name = ModuleHabitation
-		KerbalMonths = 0
-		BaseHabMultiplier = 3.5 //equal to mass
+		BaseKerbalMonths = 0
+		%CrewCapacity = #$/CrewCapacity$ 
+		@CrewCapacity *= 2
+		%BaseHabMultiplier = #$/mass$ 
+		@BaseHabMultiplier *= .9
+		%ConverterName = Habitat
+		%StartActionName = Start Habitat
+		%StopActionName = Stop Habitat		
+		%INPUT_RESOURCE[ElectricCharge]
+		{
+			%Ratio = #$../BaseHabMultiplier$
+			@Ratio *= .5
+		}
 	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
+	
+	!RESOURCE[ReplacementParts]{}
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 100
+        	maxAmount = 100
+        	@amount *= #$/CrewCapacity$
+        	@maxAmount *= #$/CrewCapacity$
+	}
 }
 
-//PXL-2 Pressurized Conical Storage Container
-@PART[crewtube-25-375-1]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 1800 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 1800
-	}
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 14 //mass * 5
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-
-//PTD-02 Pressurized Crew Tube
-@PART[crewtube-125-1]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 1.25 //mass * 5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 125 //100 * Kerbal-Months
-		%maxAmount = 125
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//PTD-01 Pressurized Crew Tube
-@PART[crewtube-125-2]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 2.5 //mass * 5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 250 //100 * Kerbal-Months
-		%maxAmount = 250
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//PPD-A2 Pressurized Crew Tube
-@PART[crewtube-25-1]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 6.25
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 625 //100 * Kerbal-Months
-		%maxAmount = 625
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//PPD-A4 Pressurized Crew Tube
-@PART[crewtube-25-2]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 12.5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 1250 //100 * Kerbal-Months
-		%maxAmount = 1250
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
 
 //Kerbalmax Brand Observation Window
 @PART[crewtube-cupola-125]:NEEDS[USILifeSupport]
 {
-	%MODULE[ModuleLifeSupport] { }
+	%MODULE[ModuleLifeSupport]{}
+	%MODULE[USI_ModuleFieldRepair]{}
 
+	!MODULE[ModuleHabitation]{}
 	MODULE
 	{
 		name = ModuleHabitation
-		KerbalMonths = 0 
-		BaseHabMultiplier = 0.09 //= mass
+		BaseKerbalMonths = 0 
+		CrewCapacity = 1
+		BaseHabMultiplier = 0.2
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1 
+		}
 	}
 
-	%MODULE[USI_ModuleFieldRepair] { }
+	!RESOURCE[ReplacementParts]{}
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = 100
+       		maxAmount = 100
+	}
 }
 
-//PTD-HEX Multi-Point Station Connector
-@PART[crewhub-125-1]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 6.25
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 625 //100 * Kerbal-Months
-		%maxAmount = 625
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//PPD-HEX Multi-Point Station Connector
-@PART[crewhub-25-1]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 12.5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 1250 //100 * Kerbal-Months
-		%maxAmount = 1250
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//Kerbalmax RGB-003 'Intercedor' Station Core
-@PART[crewtube-hub-125]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 2.5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 250 //100 * Kerbal-Months
-		%maxAmount = 250
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
-//Kerbalmax RGB-2 'Distributor' Station Core
-@PART[crewtube-hub-25]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 7.5
-	}
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 750 //100 * Kerbal-Months
-		%maxAmount = 750
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
+//PPD-A2 Pressurized Crew Tubes
+//PPD-A4 Pressurized Crew Tubes
+//Parts have no crew capacity so crew capacity is based on mass as compared to stock hitchhiker
+//@PART[crewtube-25-1|crewtube-25-2]:NEEDS[USILifeSupport]
+//{
+//	%MODULE[ModuleLifeSupport]{}
+//	%MODULE[USI_ModuleFieldRepair]{}
+//
+//	!MODULE[ModuleHabitation]{}
+//	MODULE
+//	{
+//		name = ModuleHabitation
+//		BaseKerbalMonths = #$/mass$ 
+//		@BaseKerbalMonths *= 10
+//		CrewCapacity = #$/mass$
+//		@CrewCapacity *= 1.6 
+//		BaseHabMultiplier = 0
+//		ConverterName = Habitat
+//		StartActionName = Start Habitat
+//		StopActionName = Stop Habitat		
+//		INPUT_RESOURCE
+//		{
+//			ResourceName = ElectricCharge
+//			Ratio = #$../BaseKerbalMonths$ 
+//			@Ratio *= .25
+//		}
+//	}
+//	
+//	!RESOURCE[ReplacementParts]{}
+//	RESOURCE
+//	{
+//		name = ReplacementParts
+//		amount = #$/mass$ 
+//		@amount *= 1000
+//		maxAmount = #$amount$
+//	}
+//}


### PR DESCRIPTION
This replaces the existing patch for USI-LS 0.5.x. RoverDude reworked and re-balanced many aspects of USI-LS.  This patch updates and balances the parts in SSPX. Here are some of the changes in the new version of USI-LS:

- For the most part everything is balanced based on mass (habitation time, habitation multipliers, and recyclers)
- USI-LS adds ModuleLifeSupport, ModuleFieldRepair, and ReplacementParts to all parts with crew capacity
- USI-LS automatically calculates habitation based on crew capacity (default .25 kerbal months per crew capacity)
- ModuleHabitation allows for adding extra hab time and/or hab multipliers and is now a converter and requires electric charge
- ModuleHabitation is only being used on specific parts 
- In stock parts implementing ModuleHabitation, the equation for BaseKerbalMonths is (Mass x 10 - CrewCapacity); the equation for EC is (BaseKerbalMonths x .25); and the equation for ReplacementParts is (Mass x 1000)
- I could not ascertain a clear formula for BaseHabMultiplier and have approximated the USI-LS changes to the stock cuppola (PPD-12). The equation for BaseHabMultiplier appears to be (Mass x .9); for EC (BaseHabMultiplier x .5); and ReplacementParts are based on the part's actual CrewCapacity

Changes for SSPX:

- Removed ModuleHabitation from all non-crewed parts.  As ModuleHabitation is now a converter which requires EC and must be activated this seemed like the logical choice for the 1.25 crew tubes, the station cores, and the station hubs.  I'm a little torn about the 2.5 crew tubes because of their mass so I have included a commented out patch for them which you or SSPX users can uncomment. Due to the lack of crew capacity this could get wonky in the future if RD changes the underlying code.

- Added BaseKerbalMonths to the PPD-20 Shanty Habitation Module, the PXL-1 'Hostel' Deep-Space Habitation Module, and the PXL-2 Pressurized Conical Storage Container. The months and EC are based on their mass and balanced against the USI-LS changes to the stock Hitchhiker

- Added BaseHabMultiplier to the PPD-24 Observation Module, the PXL-9 Extra-Planetary Octo-Aperture Module, and the Kerbalmax Brand Observation Window. The multiplier and EC are based on mass and roughly balanced against the stock PPD-12 cuppola.